### PR TITLE
Remove call to setDefaultAnnotationNamespace

### DIFF
--- a/Service/GearmanCacheLoader.php
+++ b/Service/GearmanCacheLoader.php
@@ -55,7 +55,6 @@ class GearmanCacheLoader extends ContainerAware
     {
         $reader = new AnnotationReader();
         AnnotationRegistry::registerFile(__DIR__ . "/../Driver/Gearman/GearmanAnnotations.php");
-        $reader->setDefaultAnnotationNamespace('Mmoreramerino\GearmanBundle\Driver\\');
         $workerCollection = new WorkerCollection;
         $bundles = $this->container->get('kernel')->getBundles();
 


### PR DESCRIPTION
`AnnotationReader::setDefaultAnnotationNamespace` was removed in Doctrine\Common 2.2 (see [UPGRADING_2_2](https://github.com/doctrine/common/blob/2.2.1/UPGRADE_TO_2_2)).

After this change is merged, you will need to ensure your annotated classes import the proper annotation namespace explicitly (or use fully qualified annotations). Example...

``` php
<?php
namespace Acme\HellBundle\Worker;
// ...snip...

use Mmoreramerino\GearmanBundle\Driver\Gearman;

/** 
 * @Gearman\Work(...) 
 */
class HelloWorker 
{
     // ...snip...

     /**
      * @Gearman\Job(...)
      */
     public function someJob(\GearmanJob $job) { /*...*/ }


}
```
