### PR TITLE
Clean up handling/naming of parameter "config.path"

### DIFF
--- a/lib/Mmoreramerino/GearmanBundle/Resources/config/services.yml
+++ b/lib/Mmoreramerino/GearmanBundle/Resources/config/services.yml
@@ -1,5 +1,5 @@
 parameters:
-    config.path:                /config/gearman/
+    gearman.config.path:        %kernel.root_dir%/config/gearman/%kernel.environment%.yml
 
     gearman.client.class:       Mmoreramerino\GearmanBundle\Service\GearmanClient
     gearman.cache.class:        Mmoreramerino\GearmanBundle\Service\GearmanCache

--- a/lib/Mmoreramerino/GearmanBundle/Service/GearmanSettings.php
+++ b/lib/Mmoreramerino/GearmanBundle/Service/GearmanSettings.php
@@ -76,7 +76,7 @@ class GearmanSettings extends ContainerAware
     {
         if (null === $this->filepath) {
             $rootDir = $this->container->get('kernel')->getRootDir();
-            $this->filepath = $rootDir . $this->container->getParameter('config.path') . $this->container->get('kernel')->getEnvironment().'.yml';
+            $this->filepath = $this->container->getParameter('gearman.config.path');
         }
 
         return $this->filepath;


### PR DESCRIPTION
- Rename config.path to gearman.config.path to avoid parameter clutter in services container
- Construct full path spec in configuration rather than in code
