### PR TITLE
Update lib/Mmoreramerino/GearmanBundle/Service/GearmanClient.php

### DIFF
--- a/lib/Mmoreramerino/GearmanBundle/Service/GearmanClient.php
+++ b/lib/Mmoreramerino/GearmanBundle/Service/GearmanClient.php
@@ -173,7 +173,7 @@ class GearmanClient extends GearmanService
      * @param string $unique A unique ID used to identify a particular task
      *
      * @return string A string representing the results of running a task.
-     * @depracated
+     * @deprecated
      */
     public function doJob($name, $params = array(), $unique = null)
     {


### PR DESCRIPTION
fixed typo, that throws   [Doctrine\Common\Annotations\AnnotationException]
  [Semantical Error] The annotation "@depracated" in method Mmoreramerino\GearmanBundle\Service\GearmanClient::doJob() was never imported. Did yo
  u maybe forget to add a "use" statement for this annotation?
