### PR TITLE
added check for php file in the GearmanCacheWrapper

### DIFF
--- a/Service/GearmanCacheWrapper.php
+++ b/Service/GearmanCacheWrapper.php
@@ -265,7 +265,7 @@ class GearmanCacheWrapper
             /**
              * File is checked to be parsed
              */
-            if( strtolower( $file->getExtension() ) != 'php') {
+            if('php' !== strtolower($file->getExtension())) {
                 continue;
             }
             


### PR DESCRIPTION
The GearmanCacheWrapper looks at all the files in the bundle, including images and other stuff.
Then it checks for a classname as if they all were php files, hence this edit.
