### PR TITLE
Fixed #81. Removed obsolete ‘Job’ concatenation in callJob

### DIFF
--- a/Service/GearmanClient.php
+++ b/Service/GearmanClient.php
@@ -281,7 +281,7 @@ class GearmanClient extends AbstractGearmanService
     public function callJob($name, $params = '', $unique = null)
     {
        $worker = $this->getJob($name);
-       $methodCallable = $worker['job']['defaultMethod'] . 'Job';
+       $methodCallable = $worker['job']['defaultMethod'];
 
        return $this->enqueue($name, $params, $methodCallable, $unique);
     }


### PR DESCRIPTION
https://github.com/mmoreram/GearmanBundle/issues/81
