### PR TITLE
--quiet should work for worker execution

### DIFF
--- a/Command/GearmanWorkerExecuteCommand.php
+++ b/Command/GearmanWorkerExecuteCommand.php
@@ -62,7 +62,7 @@ class GearmanWorkerExecuteCommand extends ContainerAwareCommand
         $worker = $input->getArgument('worker');
         $workerStruct = $this->getContainer()->get('gearman')->getWorker($worker);
 
-        if (!$input->getOption('no-description') || !$input->getOption('quiet')) {
+        if (!$input->getOption('no-description') && !$input->getOption('quiet')) {
             $this->getContainer()->get('gearman.describer')->describeWorker($output, $workerStruct, true);
         }
 


### PR DESCRIPTION
The Option "--quiet" is a Standard-Option for Symfony2 Console so it should also work to get silent starts of jobs. Because of compability-reasons the option --no-description was left in the Command.
