### PR TITLE
Added GearmanTask to GearmanClientCallbackExceptionEvent.

### DIFF
--- a/Dispatcher/GearmanCallbacksDispatcher.php
+++ b/Dispatcher/GearmanCallbacksDispatcher.php
@@ -152,9 +152,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
      *
      * @see http://www.php.net/manual/en/gearmanclient.setexceptioncallback.php
      */
-    public function assignExceptionCallback()
+    public function assignExceptionCallback(GearmanTask $gearmanTask)
     {
-        $event = new GearmanClientCallbackExceptionEvent;
+        $event = new GearmanClientCallbackExceptionEvent($gearmanTask);
         $this->eventDispatcher->dispatch(
             GearmanEvents::GEARMAN_CLIENT_CALLBACK_EXCEPTION,
             $event

--- a/Event/GearmanClientCallbackExceptionEvent.php
+++ b/Event/GearmanClientCallbackExceptionEvent.php
@@ -13,14 +13,14 @@
 
 namespace Mmoreram\GearmanBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Mmoreram\GearmanBundle\Event\Abstracts\AbstractGearmanClientTaskEvent;
 
 /**
  * GearmanClientCallbackExceptionEvent
  *
  * @since 2.3.1
  */
-class GearmanClientCallbackExceptionEvent extends Event
+class GearmanClientCallbackExceptionEvent extends AbstractGearmanClientTaskEvent
 {
 
 }


### PR DESCRIPTION
The ::setExceptionCallback provides the GearmanTask to the function.
This was tested with PECL Gearman 1.1.2

Successfully tested with the event:
gearman.client.callback.exception

http://www.php.net/manual/en/gearmanclient.setexceptioncallback.php
It doesn't mention that the task is provided at current time, however I have tested that it is.

https://github.com/mmoreram/GearmanBundle/issues/59
