### PR TITLE
ref #121 Public access to native GearmanClient instance

### DIFF
--- a/Service/GearmanClient.php
+++ b/Service/GearmanClient.php
@@ -27,6 +27,13 @@ use Mmoreram\GearmanBundle\Service\Abstracts\AbstractGearmanService;
 class GearmanClient extends AbstractGearmanService
 {
     /**
+     * @var \GearmanClient
+     *
+     * Gearman native client instance
+     */
+    protected $gearmanClient;
+
+    /**
      * @var GearmanCallbacksDispatcher
      *
      * Gearman callbacks dispatcher
@@ -74,6 +81,16 @@ class GearmanClient extends AbstractGearmanService
      * Return code from internal client.
      */
     protected $returnCode;
+
+    /**
+     * @return \GearmanClient
+     */
+    public function getNativeClient(){
+        if ($this->gearmanClient === null){
+            $this->gearmanClient = new \GearmanClient();
+        }
+        return $this->gearmanClient;
+    }
 
     /**
      * Init tasks structure
@@ -229,7 +246,7 @@ class GearmanClient extends AbstractGearmanService
      */
     protected function doEnqueue(array $worker, $params, $method, $unique)
     {
-        $gearmanClient = new \GearmanClient();
+        $gearmanClient = $this->getNativeClient();
         $this->assignServers($gearmanClient);
 
         $result = $gearmanClient->$method($worker['job']['realCallableName'], $params, $unique);
@@ -426,7 +443,7 @@ class GearmanClient extends AbstractGearmanService
      */
     public function getJobStatus($idJob)
     {
-        $gearmanClient = new \GearmanClient();
+        $gearmanClient = $this->getNativeClient();
         $this->assignServers($gearmanClient);
         $statusData = $gearmanClient->jobStatus($idJob);
 
@@ -642,7 +659,7 @@ class GearmanClient extends AbstractGearmanService
      */
     public function runTasks()
     {
-        $gearmanClient = new \GearmanClient();
+        $gearmanClient = $this->getNativeClient();
         $this->assignServers($gearmanClient);
 
         if ($this->settings['callbacks']) {

--- a/Service/GearmanClient.php
+++ b/Service/GearmanClient.php
@@ -252,6 +252,8 @@ class GearmanClient extends AbstractGearmanService
         $result = $gearmanClient->$method($worker['job']['realCallableName'], $params, $unique);
         $this->returnCode = $gearmanClient->returnCode();
 
+        $this->gearmanClient = null;
+
         return $result;
     }
 
@@ -448,6 +450,8 @@ class GearmanClient extends AbstractGearmanService
         $statusData = $gearmanClient->jobStatus($idJob);
 
         $jobStatus = new JobStatus($statusData);
+
+        $this->gearmanClient = null;
 
         return $jobStatus;
     }
@@ -685,6 +689,8 @@ class GearmanClient extends AbstractGearmanService
         }
 
         $this->initTaskStructure();
+
+        $this->gearmanClient = null;
 
         return $gearmanClient->runTasks();
     }


### PR DESCRIPTION
For access to many native client method without write proxy for every native method

Example:
/** @var Mmoreram\GearmanBundle\Service\GearmanClient $gearman */
$gearman = $container->get('gearman');
$gearman->getNativeClient()->setTimeout(100);
$gearman->doNormalJob('AcmeBundleWorkerAcmeWorker~someJob', $params);