### PR TITLE
Updated composer.json to use symfony/symfony-framework >=2.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
     ],
     "require": {
         "php": ">=5.3.3",
-        "symfony/framework-bundle": ">=2.2",
+        "symfony/framework-bundle": ">=2.4",
         "doctrine/common": ">=2.2",
         "symfony/console": ">=2.1",
         "symfony/config": ">=2.1",


### PR DESCRIPTION
Prior to dependency change projects using symfony 2.2 - 2.3 can use the package.
However commands will break due to commands as services being introduced in 2.4

Although this creates a BC break for composer updates, projects using this and symfony <2.4
would not have functioned properly regardless.
