### PR TITLE
option no-description was not working, fixed

### DIFF
--- a/Command/GearmanJobExecuteCommand.php
+++ b/Command/GearmanJobExecuteCommand.php
@@ -163,7 +163,10 @@ class GearmanJobExecuteCommand extends AbstractGearmanCommand
             ->gearmanClient
             ->getJob($job);
 
-        if (!$input->getOption('quiet')) {
+        if (
+            !$input->getOption('no-description') &&
+            !$input->getOption('quiet')
+        ) {
 
             $this
                 ->gearmanDescriber


### PR DESCRIPTION
GearmanJobExecuteCommand's option no-description wasn't working, the description disappeared only with quiet option.
