### PR TITLE
New GEARMAN_WORK_STARTING event on new job

### DIFF
--- a/Event/GearmanWorkStartingEvent.php
+++ b/Event/GearmanWorkStartingEvent.php
@@ -1,0 +1,51 @@
+<?php
+
+/**
+ * Gearman Bundle for Symfony2
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\GearmanBundle\Event;
+
+use Symfony\Component\EventDispatcher\Event;
+
+/**
+ * GearmanWorkStartingEvent
+ *
+ * @author David Moreau <dmoreau@lafourchette.com>
+ */
+class GearmanWorkStartingEvent extends Event
+{
+    /**
+     * @var array
+     *
+     * Gearman jobs running
+     */
+    protected $jobs;
+
+    /**
+     * Construct method
+     *
+     * @param array $jobs Jobs
+     */
+    public function __construct(array $jobs)
+    {
+        $this->jobs = $jobs;
+    }
+
+    /**
+     * Get Gearman Work subscribed jobs
+     *
+     * @return array Subscribed jobs
+     */
+    public function getJobs()
+    {
+        return $this->jobs;
+    }
+}

--- a/GearmanEvents.php
+++ b/GearmanEvents.php
@@ -115,4 +115,13 @@ class GearmanEvents
      * @var string
      */
     const GEARMAN_WORK_EXECUTED = 'gearman.work.executed';
+
+    /**
+     * Sets a function to be called when a worker is starting a job.
+     *
+     * This will be fired when the worker start another work cycle.
+     *
+     * @var string
+     */
+    const GEARMAN_WORK_STARTING = 'gearman.work.starting';
 }

--- a/Resources/docs/kernel_events.rst
+++ b/Resources/docs/kernel_events.rst
@@ -129,6 +129,22 @@ The second method will return `$context` that you could add in the `addTask()` m
             tags:
               - { name: kernel.event_listener, event: gearman.client.callback.workload, method: onWorkload }
 
+Starting Work Event
+~~~~~~~~~~~~~~~~~~
+
+This event receives as parameter an instanceof `Mmoreram\GearmanBundle\Event\GearmanWorkStartingEvent` with one method:
+`$event->getJobs()` returns the configuration of the jobs.
+
+This event is dispatched before a job starts.
+
+.. code-block:: yml
+
+    services:
+        my_event_listener:
+            class: AcmeBundle\EventListener\MyEventListener
+            tags:
+              - { name: kernel.event_listener, event: gearman.work.starting, method: onWorkStarting }
+
 Execute Work Event
 ~~~~~~~~~~~~~~~~~~
 

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -98,14 +98,15 @@ class GearmanExecute extends AbstractGearmanService
      * Executes a job given a jobName and given settings and annotations of job
      *
      * @param string $jobName Name of job to be executed
+     * @param GearmanWorker $gearmanWorker Worker instance to use
      */
-    public function executeJob($jobName)
+    public function executeJob($jobName, \GearmanWorker $gearmanWorker = null)
     {
         $worker = $this->getJob($jobName);
 
         if (false !== $worker) {
 
-            $this->callJob($worker);
+            $this->callJob($worker, $gearmanWorker);
         }
     }
 
@@ -113,12 +114,14 @@ class GearmanExecute extends AbstractGearmanService
      * Given a worker, execute GearmanWorker function defined by job.
      *
      * @param array $worker Worker definition
-     *
+     * @param GearmanWorker $gearmanWorker Worker instance to use
      * @return GearmanExecute self Object
      */
-    private function callJob(Array $worker)
+    private function callJob(Array $worker, \GearmanWorker $gearmanWorker = null)
     {
-        $gearmanWorker = new \GearmanWorker;
+        if(is_null($gearmanWorker)){
+            $gearmanWorker = new \GearmanWorker;
+        }
 
         if (isset($worker['job'])) {
 

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -21,6 +21,7 @@ use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
 use Mmoreram\GearmanBundle\Command\Util\GearmanOutputAwareInterface;
 use Mmoreram\GearmanBundle\Event\GearmanWorkExecutedEvent;
+use Mmoreram\GearmanBundle\Event\GearmanWorkStartingEvent;
 use Mmoreram\GearmanBundle\GearmanEvents;
 use Mmoreram\GearmanBundle\Service\Abstracts\AbstractGearmanService;
 
@@ -211,6 +212,7 @@ class GearmanExecute extends AbstractGearmanService
                 array(
                     'job_object_instance' => $objInstance,
                     'job_method' => $job['methodName'],
+                    'jobs' => $jobs
                 )
             );
         }
@@ -301,8 +303,12 @@ class GearmanExecute extends AbstractGearmanService
             || !array_key_exists('job_object_instance', $context)
             || !array_key_exists('job_method', $context)
         ) {
-            
+            throw new \InvalidArgumentException('$context shall be an array with job_object_instance and job_method key.');
         }
+
+        $event = new GearmanWorkStartingEvent($context['jobs']);
+        $this->eventDispatcher->dispatch(GearmanEvents::GEARMAN_WORK_STARTING, $event);
+
         $result = call_user_func_array(
             array($context['job_object_instance'], $context['job_method']),
             array($job, $context)

--- a/Tests/Service/GearmanExecuteTest.php
+++ b/Tests/Service/GearmanExecuteTest.php
@@ -79,9 +79,13 @@ class GearmanExecuteTest extends WebTestCase
             ->willReturn($workers);
 
         // Prepare a dispatcher to listen to tested events
+        $startingFlag = false;
         $executedFlag = false;
 
         $dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        $dispatcher->addListener(GearmanEvents::GEARMAN_WORK_STARTING, function() use (&$startingFlag){
+            $startingFlag = true;
+        });
         $dispatcher->addListener(GearmanEvents::GEARMAN_WORK_EXECUTED, function() use (&$executedFlag){
             $executedFlag = true;
         });
@@ -98,7 +102,8 @@ class GearmanExecuteTest extends WebTestCase
         $worker->method('work')->will($this->returnCallback(function() use ($service, $object){
             $service->handleJob(new \GearmanJob(), array(
                 'job_object_instance' => $object,
-                'job_method' => 'myMethod'
+                'job_method' => 'myMethod',
+                'jobs' => array()
             ));
             return true;
         }));
@@ -107,6 +112,7 @@ class GearmanExecuteTest extends WebTestCase
         $service->executeJob('test', $worker);
 
         // Do we have the events ?
+        $this->assertTrue($startingFlag);
         $this->assertTrue($executedFlag);
     }
 }

--- a/Tests/Service/GearmanExecuteTest.php
+++ b/Tests/Service/GearmanExecuteTest.php
@@ -13,7 +13,9 @@
 
 namespace Mmoreram\GearmanBundle\Tests\Service;
 
+use Mmoreram\GearmanBundle\Service\GearmanExecute;
 use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use Mmoreram\GearmanBundle\GearmanEvents;
 
 /**
  * Tests GearmanExecute class
@@ -35,5 +37,76 @@ class GearmanExecuteTest extends WebTestCase
                 ->getContainer()
                 ->get('gearman.execute')
         );
+    }
+
+    public function testDispatchingEventsOnJob()
+    {
+        // Worker mock
+        $worker = $this->getMockBuilder('\GearmanWorker')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $worker->method('addServer')->willReturn(true);
+
+        // Wrapper mock
+        $workers = array(
+            0 => array(
+                'className'    => "Mmoreram\\GearmanBundle\\Tests\\Service\\Mocks\\SingleCleanFile",
+                'fileName'     => dirname(__FILE__) . '/Mocks/SingleCleanFile.php',
+                'callableName' => null,
+                'description'  => "test",
+                'service'      => false,
+                'servers'      => array(),
+                'iterations'   => 1,
+                'jobs' => array(
+                    0 => array(
+                        'callableName'             => "test",
+                        'methodName'               => "test",
+                        'realCallableName'         => "test",
+                        'jobPrefix'                => NULL,
+                        'realCallableNameNoPrefix' => "test",
+                        'description'              => "test",
+                        'iterations'               => 1,
+                        'servers'                  => array(),
+                        'defaultMethod'            => "doBackground"
+                    )
+                )
+            )
+        );
+        $wrapper = $this->getMockBuilder('Mmoreram\GearmanBundle\Service\GearmanCacheWrapper')
+            ->disableOriginalConstructor()
+            ->getMock();
+        $wrapper->method('getWorkers')
+            ->willReturn($workers);
+
+        // Prepare a dispatcher to listen to tested events
+        $executedFlag = false;
+
+        $dispatcher = new \Symfony\Component\EventDispatcher\EventDispatcher();
+        $dispatcher->addListener(GearmanEvents::GEARMAN_WORK_EXECUTED, function() use (&$executedFlag){
+            $executedFlag = true;
+        });
+
+        // Create the service under test
+        $service = new GearmanExecute($wrapper, array());
+        $service->setEventDispatcher($dispatcher);
+
+        // We need a job object, this part could be improved
+        $object = new \Mmoreram\GearmanBundle\Tests\Service\Mocks\SingleCleanFile();
+
+        // Finalize worker mock by making it call our job object
+        // This is normally handled by Gearman, but for test purpose we must simulate it
+        $worker->method('work')->will($this->returnCallback(function() use ($service, $object){
+            $service->handleJob(new \GearmanJob(), array(
+                'job_object_instance' => $object,
+                'job_method' => 'myMethod'
+            ));
+            return true;
+        }));
+
+        // Execute a job :)
+        $service->executeJob('test', $worker);
+
+        // Do we have the events ?
+        $this->assertTrue($executedFlag);
     }
 }


### PR DESCRIPTION
In order to implement a clean worker shutdown (incoming pull request), I need a new event to be dispatched when a worker starts to process a new job. I added testing for the existing GEARMAN_WORK_EXECUTED event, and for the new one.

I opened also a [pull request](https://github.com/lafourchette/GearmanBundle/pull/1) against our company fork.