### PR TITLE
Patch added to improve resilience to several types of failure.

### DIFF
--- a/Command/GearmanJobExecuteCommand.php
+++ b/Command/GearmanJobExecuteCommand.php
@@ -119,6 +119,24 @@ class GearmanJobExecuteCommand extends AbstractGearmanCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Don\'t print job description'
+            )
+            ->addOption(
+                'iterations',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured iterations'
+            )
+            ->addOption(
+                'minimum-execution-time',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured minimum execution time'
+            )
+            ->addOption(
+                'timeout',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured timeout'
             );
     }
 
@@ -188,6 +206,10 @@ class GearmanJobExecuteCommand extends AbstractGearmanCommand
         $this
             ->gearmanExecute
             ->setOutput($output)
-            ->executeJob($job);
+            ->executeJob($job, array(
+                'iterations'             => $input->getOption('iterations'),
+                'minimum_execution_time' => $input->getOption('minimum-execution-time'),
+                'timeout'                => $input->getOption('timeout')
+            ));
     }
 }

--- a/Command/GearmanWorkerExecuteCommand.php
+++ b/Command/GearmanWorkerExecuteCommand.php
@@ -114,6 +114,24 @@ class GearmanWorkerExecuteCommand extends AbstractGearmanCommand
                 null,
                 InputOption::VALUE_NONE,
                 'Don\'t print worker description'
+            )
+            ->addOption(
+                'iterations',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured iterations'
+            )
+            ->addOption(
+                'minimum-execution-time',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured minimum execution time'
+            )
+            ->addOption(
+                'timeout',
+                null,
+                InputOption::VALUE_OPTIONAL,
+                'Override configured timeout'
             );
     }
 
@@ -184,6 +202,10 @@ class GearmanWorkerExecuteCommand extends AbstractGearmanCommand
         $this
             ->gearmanExecute
             ->setOutput($output)
-            ->executeWorker($worker);
+            ->executeWorker($worker, array(
+                'iterations'             => $input->getOption('iterations'),
+                'minimum_execution_time' => $input->getOption('minimum-execution-time'),
+                'timeout'                => $input->getOption('timeout')
+            ));
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -96,6 +96,12 @@ class Configuration implements ConfigurationInterface
                         ->scalarNode('workers_name_prepend_namespace')
                             ->defaultTrue()
                         ->end()
+                        ->scalarNode('minimum_execution_time')
+                            ->defaultNull()
+                        ->end()
+                        ->scalarNode('timeout')
+                            ->defaultNull()
+                        ->end()
                     ->end()
                 ->end()
             ->end();

--- a/Driver/Gearman/Job.php
+++ b/Driver/Gearman/Job.php
@@ -58,4 +58,18 @@ class Job extends Annotation
      * @var string
      */
     public $defaultMethod;
+
+    /**
+     * Timeout in seconds for job idle time
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
+     * @var int
+     *
+     * Number of seconds the execution must run before being allowed to terminate
+     */
+    public $minimumExecutionTime;
 }

--- a/Driver/Gearman/Work.php
+++ b/Driver/Gearman/Work.php
@@ -60,6 +60,20 @@ class Work extends Annotation
     public $defaultMethod;
 
     /**
+     * Default timeout in seconds for worker idle time
+     *
+     * @var int
+     */
+    public $timeout;
+
+    /**
+     * @var int
+     *
+     * Default number of seconds the execution must run before being allowed to terminate
+     */
+    public $minimumExecutionTime;
+
+    /**
      * Service typeof Class. If it's defined, object will be instanced throught
      * service dependence injection.
      * Otherwise, class will be instance with new() method

--- a/Exceptions/ServerConnectionException.php
+++ b/Exceptions/ServerConnectionException.php
@@ -1,0 +1,26 @@
+<?php
+
+/**
+ * Gearman Bundle for Symfony2
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\GearmanBundle\Exceptions;
+
+use Mmoreram\GearmanBundle\Exceptions\Abstracts\AbstractGearmanException;
+
+/**
+ * GearmanBundle can't connect to server Exception
+ *
+ * @since 2.3.1
+ */
+class ServerConnectionException extends AbstractGearmanException
+{
+
+}

--- a/Module/JobClass.php
+++ b/Module/JobClass.php
@@ -88,6 +88,13 @@ class JobClass extends ContainerAware
     private $defaultMethod;
 
     /**
+     * @var int
+     *
+     * Timeout for idle worker
+     */
+    private $timeout;
+
+    /**
      * @var array
      *
      * Collection of servers to connect
@@ -137,6 +144,8 @@ class JobClass extends ContainerAware
 
         $this->servers = $this->loadServers($jobAnnotation, $servers);
         $this->iterations = $this->loadIterations($jobAnnotation, $defaultSettings);
+        $this->minimumExecutionTime = $this->loadMinimumExecutionTime($jobAnnotation, $defaultSettings);
+        $this->timeout = $this->loadTimeout($jobAnnotation, $defaultSettings);
         $this->defaultMethod = $this->loadDefaultMethod($jobAnnotation, $defaultSettings);
     }
 
@@ -204,6 +213,42 @@ class JobClass extends ContainerAware
     }
 
     /**
+     * Load minimumExecutionTime
+     *
+     * If minimumExecutionTime is defined in JobAnnotation, this one is used.
+     * Otherwise is used set in Class
+     *
+     * @param JobAnnotation $jobAnnotation
+     * @param array $defaultSettings
+     *
+     * @return int
+     */
+    private function loadMinimumExecutionTime(JobAnnotation $jobAnnotation, array $defaultSettings)
+    {
+        return is_null($jobAnnotation->minimumExecutionTime)
+            ? (int) $defaultSettings['minimumExecutionTime']
+            : (int) $jobAnnotation->minimumExecutionTime;
+    }
+
+    /**
+     * Load timeout
+     *
+     * If timeout is defined in JobAnnotation, this one is used.
+     * Otherwise is used set in Class
+     *
+     * @param JobAnnotation $jobAnnotation
+     * @param array $defaultSettings
+     *
+     * @return int
+     */
+    private function loadTimeout(JobAnnotation $jobAnnotation, array $defaultSettings)
+    {
+        return is_null($jobAnnotation->timeout)
+            ? (int) $defaultSettings['timeout']
+            : (int) $jobAnnotation->timeout;
+    }
+
+    /**
      * Retrieve all Job data in cache format
      *
      * @return array
@@ -219,6 +264,8 @@ class JobClass extends ContainerAware
             'realCallableNameNoPrefix' => $this->realCallableNameNoPrefix,
             'description'              => $this->description,
             'iterations'               => $this->iterations,
+            'minimumExecutionTime'     => $this->minimumExecutionTime,
+            'timeout'                  => $this->timeout,
             'servers'                  => $this->servers,
             'defaultMethod'            => $this->defaultMethod,
         );

--- a/Module/WorkerClass.php
+++ b/Module/WorkerClass.php
@@ -242,6 +242,17 @@ class WorkerClass
             : $workAnnotation->defaultMethod;
     }
 
+    /**
+     * Load minimumExecutionTime
+     *
+     * If minimumExecutionTime is defined in JobAnnotation, this one is used.
+     * Otherwise is used set in Class
+     *
+     * @param JobAnnotation $jobAnnotation
+     * @param array $defaultSettings
+     *
+     * @return int
+     */
     private function loadMinimumExecutionTime(WorkAnnotation $workAnnotation, array $defaultSettings)
     {
         return is_null($workAnnotation->minimumExecutionTime)
@@ -249,6 +260,17 @@ class WorkerClass
             : (int) $workAnnotation->minimumExecutionTime;
     }
 
+    /**
+     * Load timeout
+     *
+     * If timeout is defined in JobAnnotation, this one is used.
+     * Otherwise is used set in Class
+     *
+     * @param JobAnnotation $jobAnnotation
+     * @param array $defaultSettings
+     *
+     * @return int
+     */
     private function loadTimeout(WorkAnnotation $workAnnotation, array $defaultSettings)
     {
         return is_null($workAnnotation->timeout)

--- a/Module/WorkerClass.php
+++ b/Module/WorkerClass.php
@@ -95,6 +95,13 @@ class WorkerClass
     private $defaultMethod;
 
     /**
+     * @var int
+     *
+     * Timeout for idle worker
+     */
+    private $timeout;
+
+    /**
      * @var array
      *
      * Collection of servers to connect
@@ -168,6 +175,8 @@ class WorkerClass
         $this->servers = $this->loadServers($workAnnotation, $servers);
         $this->iterations = $this->loadIterations($workAnnotation, $defaultSettings);
         $this->defaultMethod = $this->loadDefaultMethod($workAnnotation, $defaultSettings);
+        $this->minimumExecutionTime = $this->loadMinimumExecutionTime($workAnnotation, $defaultSettings);
+        $this->timeout = $this->loadTimeout($workAnnotation, $defaultSettings);
         $this->jobCollection = $this->createJobCollection($reflectionClass, $reader);
     }
 
@@ -233,6 +242,20 @@ class WorkerClass
             : $workAnnotation->defaultMethod;
     }
 
+    private function loadMinimumExecutionTime(WorkAnnotation $workAnnotation, array $defaultSettings)
+    {
+        return is_null($workAnnotation->minimumExecutionTime)
+            ? (int) $defaultSettings['minimum_execution_time']
+            : (int) $workAnnotation->minimumExecutionTime;
+    }
+
+    private function loadTimeout(WorkAnnotation $workAnnotation, array $defaultSettings)
+    {
+        return is_null($workAnnotation->timeout)
+            ? (int) $defaultSettings['timeout']
+            : (int) $workAnnotation->timeout;
+    }
+
     /**
      * Creates job collection of worker
      *
@@ -265,9 +288,11 @@ class WorkerClass
                      * Creates new Job
                      */
                     $job = new Job($methodAnnotation, $reflectionMethod, $this->callableName, $this->servers, array(
-                        'jobPrefix'  => $this->jobPrefix,
-                        'iterations' => $this->iterations,
-                        'method'     => $this->defaultMethod,
+                        'jobPrefix'            => $this->jobPrefix,
+                        'iterations'           => $this->iterations,
+                        'method'               => $this->defaultMethod,
+                        'minimumExecutionTime' => $this->minimumExecutionTime,
+                        'timeout'              => $this->timeout,
                     ));
 
                     $jobCollection->add($job);
@@ -287,15 +312,17 @@ class WorkerClass
     {
         return array(
 
-            'namespace'    => $this->namespace,
-            'className'    => $this->className,
-            'fileName'     => $this->fileName,
-            'callableName' => $this->callableName,
-            'description'  => $this->description,
-            'service'      => $this->service,
-            'servers'      => $this->servers,
-            'iterations'   => $this->iterations,
-            'jobs'         => $this->jobCollection->toArray(),
+            'namespace'            => $this->namespace,
+            'className'            => $this->className,
+            'fileName'             => $this->fileName,
+            'callableName'         => $this->callableName,
+            'description'          => $this->description,
+            'service'              => $this->service,
+            'servers'              => $this->servers,
+            'iterations'           => $this->iterations,
+            'minimumExecutionTime' => $this->minimumExecutionTime,
+            'timeout'              => $this->timeout,
+            'jobs'                 => $this->jobCollection->toArray(),
         );
     }
 

--- a/Resources/docs/configuration.rst
+++ b/Resources/docs/configuration.rst
@@ -60,6 +60,16 @@ config gearman cache, using doctrine cache.
           # If empty, 0 is defined by default
           iterations: 150
 
+          # Default amount of time in seconds required for the execution to run.
+          # This is useful if using a tool such as supervisor which may expect a command to run for a
+          # minimum period of time to be considered successful and avoid fatal termination.
+          # If empty, no minimum time is required
+          minimum_execution_time: null
+
+          # Default maximum amount of time in seconds for a worker to remain idle before terminating.
+          # If empty, the worker will never timeout
+          timeout: null
+
           # execute callbacks after operations using Kernel events
           callbacks: true
 

--- a/Resources/docs/definition_workers.rst
+++ b/Resources/docs/definition_workers.rst
@@ -18,6 +18,8 @@ overwrite environment settings.
     /**
      * @Gearman\Work(
      *     iterations = 3,
+     *     minimumExecutionTime = 3,
+     *     timeout = 20,
      *     description = "Worker test description",
      *     defaultMethod = "doBackground",
      *     servers = {
@@ -37,6 +39,8 @@ overwrite environment settings.
          *
          * @Gearman\Job(
          *     iterations = 3,
+         *     minimumExecutionTime = 2,
+         *     timeout = 30,
          *     name = "test",
          *     description = "This is a description"
          * )
@@ -76,6 +80,8 @@ Worker annotations
      * @Gearman\Work(
      *     name = "MyAcmeWorker",
      *     iterations = 3,
+     *     minimumExecutionTime = 3,
+     *     timeout = 20,
      *     description = "Acme Worker. Containing multiple available jobs",
      *     defaultMethod = "doHigh",
      *     servers = {
@@ -88,6 +94,8 @@ Worker annotations
 - name : Name of work. You can associate a group of jobs with some keyword
 - description : Short description about all jobs inside
 - iterations : You can overwrite iterations of all jobs inside
+- minimumExecutionTime: You can overwrite the main default minimum execution time
+- timeout: You can overwrite the main default timeout
 - servers : array containing servers providers will connect to offer all jobs
 - service : You can use even a service. Must specify callable service name
 - defaultMethod : You can define witch method will be used as default in all
@@ -102,6 +110,8 @@ Job annotations
      * @Gearman\Job(
      *     name = "doSomething",
      *     iterations = 10,
+     *     minimumExecutionTime = 2,
+     *     timeout = 30,
      *     description = "Acme Job action. This is just a description of a method that do something",
      *     defaultMethod = "doBackground",
      *     servers = { "host": "192.168.1.1", "port": 4560 }
@@ -111,6 +121,8 @@ Job annotations
 - name : Name of job. You will use it to call job
 - description : Short description about this job. Important field
 - iterations : You can overwrite iterations of this job.
+- minimumExecutionTime: You can overwrite the worker minimum execution time
+- timeout: You can overwrite the worker timeout
 - servers : array containing servers providers will connect to offer this job
 - defaultMethod : You can define witch method will be used as default in this job
 

--- a/Resources/docs/running_jobs.rst
+++ b/Resources/docs/running_jobs.rst
@@ -128,6 +128,23 @@ itself.
           You can have as many as worker instances as you want.
           Get some `Supervisord`_ info
 
+Overriding default settings
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+From the command line you can run the jobs or workers with overridden settings.  These include
+
+- iterations
+- minimum-execution-time
+- timeout
+
+For example:
+
+.. code-block:: bash
+
+    $ php app/console gearman:job:describe MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething --iterations=5 --minimum-execution-time=2 --timeout=20
+
+If these options are ommited, then the configuration defaults are used.
+
 Request job status
 ~~~~~~~~~~~~~~~~~~
 

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -23,6 +23,8 @@ use Mmoreram\GearmanBundle\Command\Util\GearmanOutputAwareInterface;
 use Mmoreram\GearmanBundle\Event\GearmanWorkExecutedEvent;
 use Mmoreram\GearmanBundle\GearmanEvents;
 use Mmoreram\GearmanBundle\Service\Abstracts\AbstractGearmanService;
+use Mmoreram\GearmanBundle\Exceptions\ServerConnectionException;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Gearman execute methods. All Worker methods
@@ -51,6 +53,36 @@ class GearmanExecute extends AbstractGearmanService
      * Output instance
      */
     protected $output;
+
+    /**
+     * @var OptionsResolver
+     */
+    protected $executeOptionsResolver;
+
+    /**
+     * Construct method
+     *
+     * @param GearmanCacheWrapper $gearmanCacheWrapper GearmanCacheWrapper
+     * @param array               $defaultSettings     The default settings for the bundle
+     */
+    public function __construct(GearmanCacheWrapper $gearmanCacheWrapper, array $defaultSettings)
+    {
+        parent::__construct($gearmanCacheWrapper, $defaultSettings);
+
+        $this->executeOptionsResolver = new OptionsResolver();
+        $this->executeOptionsResolver
+            ->setDefaults(array(
+                'iterations'             => null,
+                'minimum_execution_time' => null,
+                'timeout'                => null
+            ))
+            ->setAllowedTypes(array(
+                'iterations'             => array('null', 'scalar'),
+                'minimum_execution_time' => array('null', 'scalar'),
+                'timeout'                => array('null', 'scalar')
+            ))
+        ;
+    }
 
     /**
      * Set container
@@ -99,13 +131,13 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @param string $jobName Name of job to be executed
      */
-    public function executeJob($jobName)
+    public function executeJob($jobName, array $options = array())
     {
         $worker = $this->getJob($jobName);
 
         if (false !== $worker) {
 
-            $this->callJob($worker);
+            $this->callJob($worker, $options);
         }
     }
 
@@ -116,25 +148,58 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @return GearmanExecute self Object
      */
-    private function callJob(Array $worker)
+    private function callJob(array $worker, array $options = array())
     {
         $gearmanWorker = new \GearmanWorker;
+        $minimumExecutionTime = null;
 
         if (isset($worker['job'])) {
 
             $jobs = array($worker['job']);
             $iterations = $worker['job']['iterations'];
-            $this->addServers($gearmanWorker, $worker['job']['servers']);
+            $minimumExecutionTime = $worker['job']['minimumExecutionTime'];
+            $timeout = $worker['job']['timeout'];
+            $this->addServers($gearmanWorker, $worker['job']['servers'], $successes);
 
         } else {
 
             $jobs = $worker['jobs'];
             $iterations = $worker['iterations'];
-            $this->addServers($gearmanWorker, $worker['servers']);
+            $minimumExecutionTime = $worker['minimumExecutionTime'];
+            $timeout = $worker['timeout'];
+            $this->addServers($gearmanWorker, $worker['servers'], $successes);
+        }
+
+        $options = $this->executeOptionsResolver->resolve($options);
+
+        $iterations           = $options['iterations']             ?: $iterations;
+        $minimumExecutionTime = $options['minimum_execution_time'] ?: $minimumExecutionTime;
+        $timeout              = $options['timeout']                ?: $timeout;
+
+        if (count($successes) < 1) {
+            sleep($minimumExecutionTime);
+            throw new ServerConnectionException('Worker was unable to connect to any server.');
         }
 
         $objInstance = $this->createJob($worker);
-        $this->runJob($gearmanWorker, $objInstance, $jobs, $iterations);
+
+        /**
+         * Start the timer before running the worker.
+         */
+        $time = time();
+        $this->runJob($gearmanWorker, $objInstance, $jobs, $iterations, $timeout);
+
+        /**
+         * If there is a minimum expected duration, wait out the remaining period if there is any.
+         */
+        if (null !== $minimumExecutionTime) {
+            $now = time();
+            $remaining = $minimumExecutionTime - ($now - $time);
+
+            if ($remaining > 0) {
+                sleep($remaining);
+            }
+        }
 
         return $this;
     }
@@ -187,9 +252,8 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @return GearmanExecute self Object
      */
-    private function runJob(\GearmanWorker $gearmanWorker, $objInstance, array $jobs, $iterations)
+    private function runJob(\GearmanWorker $gearmanWorker, $objInstance, array $jobs, $iterations, $timeout = null)
     {
-
         /**
          * Set the output of this instance, this should allow workers to use the console output.
          */
@@ -209,6 +273,10 @@ class GearmanExecute extends AbstractGearmanService
          * If iterations value is 0, is like worker will never die
          */
         $alive = (0 == $iterations);
+
+        if (null !== $timeout) {
+            $gearmanWorker->setTimeout($timeout * 1000);
+        }
 
         /**
          * Executes GearmanWorker with all jobs defined
@@ -234,7 +302,6 @@ class GearmanExecute extends AbstractGearmanService
                 break;
             }
         }
-
     }
 
     /**
@@ -243,18 +310,27 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @param \GearmanWorker $gmworker Worker to perform configuration
      * @param array          $servers  Servers array
+     *
+     * @throws ServerConnectionException if a connection to a server was not possible.
      */
-    private function addServers(\GearmanWorker $gmworker, Array $servers)
+    private function addServers(\GearmanWorker $gmworker, Array $servers, array &$successes = null)
     {
+        $successes = $successes ?: null;
+
         if (!empty($servers)) {
 
             foreach ($servers as $server) {
-
-                $gmworker->addServer($server['host'], $server['port']);
+                if (@$gmworker->addServer($server['host'], $server['port'])) {
+                    $successes[] = $server;
+                }
             }
         } else {
-            $gmworker->addServer();
+            if (@$gmworker->addServer()) {
+                $successes[] = array('127.0.0.1', 4730);
+            }
         }
+
+        return $successes;
     }
 
     /**
@@ -263,13 +339,13 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @param string $workerName Name of worker to be executed
      */
-    public function executeWorker($workerName)
+    public function executeWorker($workerName, array $options = array())
     {
         $worker = $this->getWorker($workerName);
 
         if (false !== $worker) {
 
-            $this->callJob($worker);
+            $this->callJob($worker, $options);
         }
     }
 }

--- a/Tests/Module/JobClassTest.php
+++ b/Tests/Module/JobClassTest.php
@@ -71,7 +71,7 @@ class JobClassTest extends PHPUnit_Framework_TestCase
     private $defaultSettings = array(
         'method'                         => 'doHigh',
         'iterations'                     => 100,
-        'minimum_execution_time'         => null,
+        'minimumExecutionTime'           => null,
         'timeout'                        => null,
         'callbacks'                      => true,
         'jobPrefix'                      => null,
@@ -141,6 +141,8 @@ class JobClassTest extends PHPUnit_Framework_TestCase
             'realCallableNameNoPrefix' => str_replace('\\', '', $this->callableNameClass . '~' . $this->jobAnnotation->name),
             'description'              => $this->jobAnnotation->description,
             'iterations'               => $this->jobAnnotation->iterations,
+            'minimumExecutionTime'     => $this->jobAnnotation->minimumExecutionTime,
+            'timeout'                  => $this->jobAnnotation->timeout,
             'servers'                  => $this->jobAnnotation->servers,
             'defaultMethod'            => $this->jobAnnotation->defaultMethod,
         ));
@@ -178,6 +180,8 @@ class JobClassTest extends PHPUnit_Framework_TestCase
             'realCallableNameNoPrefix' => str_replace('\\', '', $this->callableNameClass . '~' . $this->methodName),
             'description'              => $jobClass::DEFAULT_DESCRIPTION,
             'iterations'               => $this->defaultSettings['iterations'],
+            'minimumExecutionTime'     => $this->defaultSettings['minimumExecutionTime'],
+            'timeout'                  => $this->defaultSettings['timeout'],
             'servers'                  => $this->servers,
             'defaultMethod'            => $this->defaultSettings['method'],
         ));
@@ -216,6 +220,8 @@ class JobClassTest extends PHPUnit_Framework_TestCase
             'realCallableNameNoPrefix' => str_replace('\\', '', $this->callableNameClass . '~' . $this->methodName),
             'description'              => $jobClass::DEFAULT_DESCRIPTION,
             'iterations'               => $this->defaultSettings['iterations'],
+            'minimumExecutionTime'     => $this->defaultSettings['minimumExecutionTime'],
+            'timeout'                  => $this->defaultSettings['timeout'],
             'servers'                  => array($this->jobAnnotation->servers),
             'defaultMethod'            => $this->defaultSettings['method'],
         ));
@@ -257,6 +263,8 @@ class JobClassTest extends PHPUnit_Framework_TestCase
             'realCallableNameNoPrefix' => str_replace('\\', '', $this->callableNameClass . '~' . $this->methodName),
             'description'              => $jobClass::DEFAULT_DESCRIPTION,
             'iterations'               => $this->defaultSettings['iterations'],
+            'minimumExecutionTime'     => $this->defaultSettings['minimumExecutionTime'],
+            'timeout'                  => $this->defaultSettings['timeout'],
             'servers'                  => array($this->jobAnnotation->servers),
             'defaultMethod'            => $this->defaultSettings['method'],
         ));

--- a/Tests/Module/JobClassTest.php
+++ b/Tests/Module/JobClassTest.php
@@ -71,6 +71,8 @@ class JobClassTest extends PHPUnit_Framework_TestCase
     private $defaultSettings = array(
         'method'                         => 'doHigh',
         'iterations'                     => 100,
+        'minimum_execution_time'         => null,
+        'timeout'                        => null,
         'callbacks'                      => true,
         'jobPrefix'                      => null,
         'generate_unique_key'            => true,

--- a/Tests/Module/WorkerClassTest.php
+++ b/Tests/Module/WorkerClassTest.php
@@ -191,6 +191,8 @@ class WorkerClassTest extends \PHPUnit_Framework_TestCase
             'service'               =>  $this->workAnnotation->service,
             'servers'               =>  $this->workAnnotation->servers,
             'iterations'            =>  $this->workAnnotation->iterations,
+            'minimumExecutionTime'  =>  $this->workAnnotation->minimumExecutionTime,
+            'timeout'               =>  $this->workAnnotation->timeout,
             'jobs'                  =>  array(),
         ));
     }
@@ -251,6 +253,8 @@ class WorkerClassTest extends \PHPUnit_Framework_TestCase
             'service'               =>  null,
             'servers'               =>  $this->servers,
             'iterations'            =>  $this->defaultSettings['iterations'],
+            'minimumExecutionTime'  =>  $this->defaultSettings['minimum_execution_time'],
+            'timeout'               =>  $this->defaultSettings['timeout'],
             'jobs'                  =>  array(),
         ));
     }
@@ -312,6 +316,8 @@ class WorkerClassTest extends \PHPUnit_Framework_TestCase
             'service'               =>  null,
             'servers'               =>  array($this->workAnnotation->servers),
             'iterations'            =>  $this->defaultSettings['iterations'],
+            'minimumExecutionTime'  =>  $this->defaultSettings['minimum_execution_time'],
+            'timeout'               =>  $this->defaultSettings['timeout'],
             'jobs'                  =>  array(),
         ));
     }

--- a/Tests/Module/WorkerClassTest.php
+++ b/Tests/Module/WorkerClassTest.php
@@ -83,11 +83,13 @@ class WorkerClassTest extends \PHPUnit_Framework_TestCase
      * Default settings
      */
     private $defaultSettings = array(
-        'method'        =>  'doHigh',
-        'iterations'    =>  100,
-        'callbacks'     =>  true,
-        'jobPrefix'     =>  null,
-        'generate_unique_key' => true,
+        'method'                         => 'doHigh',
+        'iterations'                     => 100,
+        'minimum_execution_time'         => null,
+        'timeout'                        => null,
+        'callbacks'                      => true,
+        'jobPrefix'                      => null,
+        'generate_unique_key'            => true,
         'workers_name_prepend_namespace' => true,
     );
 

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
         "symfony/http-kernel": "~2.1",
         "symfony/console": "~2.1",
         "symfony/config": "~2.1",
-        "symfony/finder": "~2.1"
+        "symfony/finder": "~2.1",
+        "symfony/options-resolver": "~2.1"
     },
     "target-dir": "Mmoreram/GearmanBundle",
     "autoload": {


### PR DESCRIPTION
The following changes have been made:

- Added "Maximum Execution Time" to the configuration tree.

This option when used will ensure that even after a worker has
been terminated, the execution of the command does not complete
until the duration has been completed.

The purpose of this option is to ensure Supervisor does not
consider a worker to contain fatal flaws if it completes it's
task too quickly.

- Added "Timeout" to the configuration tree.

A suspected cause of worker failures are disconnections to
the gearman server.  Although the worker still waits, physically
unplugging your network cable or wireless does not impact the
worker.  This, and other causes for disconnect leaves the worker
as a zombie that Supervisor does not know needs to be restarted.

This timeout helps prevent a gearman server connection
remaining idle for too long.

- Added Server Exception.

When no server can be connected to successfully with `addServer`,
a `ServerConnectionException` is throwed in the `GearmanExecute`
service.  This will be represented at the command line.

If a minimum execution time is present, the script will still
wait before throwing the exception.  To clean the error messages,
the original warnings are supressed.

Consideration for backwards compatibility may be required here.
However given the work typically does not start when a connection
is not established, and that Supervisor treats immediate
terminations as fatal, this may not have a significant negative
(if negative at all) impact on existing systems.

- Added command line configuration options.

Iterations, Minimum Execution Time, and Timeout have been added
to the following commands:

    gearman:worker:execute
    gearman:job:execute

These options override the base configuration.