### PR TITLE
Managing context in callbacks

### DIFF
--- a/Dispatcher/GearmanCallbacksDispatcher.php
+++ b/Dispatcher/GearmanCallbacksDispatcher.php
@@ -90,9 +90,12 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
      *
      * @see http://www.php.net/manual/en/gearmanclient.setcompletecallback.php
      */
-    public function assignCompleteCallback(GearmanTask $gearmanTask)
+    public function assignCompleteCallback(GearmanTask $gearmanTask, $contextReference = null)
     {
         $event = new GearmanClientCallbackCompleteEvent($gearmanTask);
+        if (!is_null($contextReference)) {
+            $event->setContext($contextReference);
+        }
         $this->eventDispatcher->dispatch(
             GearmanEvents::GEARMAN_CLIENT_CALLBACK_COMPLETE,
             $event

--- a/Event/Abstracts/AbstractGearmanClientTaskEvent.php
+++ b/Event/Abstracts/AbstractGearmanClientTaskEvent.php
@@ -29,6 +29,13 @@ abstract class AbstractGearmanClientTaskEvent extends Event
     protected $gearmanTask;
 
     /**
+     * @var mixed
+     *
+     * Context that can be set in the addTask method
+     */
+    protected $context;
+
+    /**
      * Construct method
      *
      * @param GearmanTask $gearmanTask Gearman Task
@@ -46,5 +53,21 @@ abstract class AbstractGearmanClientTaskEvent extends Event
     public function getGearmanTask()
     {
         return $this->gearmanTask;
+    }
+
+    /**
+     * @param mixed $context Context that can be set in the addTask method
+     */
+    public function setContext($context)
+    {
+        $this->context = &$context['context'];
+    }
+
+    /**
+     * @return mixed Context that can be set in the addTask method
+     */
+    public function &getContext()
+    {
+        return $this->context;
     }
 }

--- a/Resources/docs/client.rst
+++ b/Resources/docs/client.rst
@@ -60,9 +60,9 @@ Tasks
 .. code-block:: php
 
     $gearman
-        ->addTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value1')
-        ->addLowTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value2')
-        ->addHighBackgroundTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value3')
+        ->addTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value1', $context1)
+        ->addLowTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value2', $context2)
+        ->addHighBackgroundTask('MmoreramerinoTestBundleServicesMyAcmeWorker~doSomething', 'value3', $context3)
         ->runTasks();
 
 - addTask: Adds a task to be run in parallel with other tasks

--- a/Resources/docs/kernel_events.rst
+++ b/Resources/docs/kernel_events.rst
@@ -6,8 +6,10 @@ GearmanBundle transforms Gearman callbacks to Symfony2 kernel events.
 Complete Callback
 ~~~~~~~~~~~~~~~~~
 
-This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackCompleteEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackCompleteEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setCompleteCallback](http://www.php.net/manual/en/gearmanclient.setcompletecallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -20,8 +22,10 @@ For more information about this GearmanEvent, read [GearmanClient::setCompleteCa
 Created Callback
 ~~~~~~~~~~~~~~~~
 
-This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackCreatedEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackCreatedEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setCreatedCallback](http://www.php.net/manual/en/gearmanclient.setcreatedcallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -34,8 +38,10 @@ For more information about this GearmanEvent, read [GearmanClient::setCreatedCal
 Data Callback
 ~~~~~~~~~~~~~
 
-This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackDataEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackDataEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setDataCallback](http://www.php.net/manual/en/gearmanclient.setdatacallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -62,8 +68,10 @@ For more information about this GearmanEvent, read [GearmanClient::setExceptionC
 Fail Callback
 ~~~~~~~~~~~~~
 
-This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackFailEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackFailEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setFailCallback](http://www.php.net/manual/en/gearmanclient.setfailcallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -76,8 +84,10 @@ For more information about this GearmanEvent, read [GearmanClient::setFailCallba
 Status Callback
 ~~~~~~~~~~~~~~~
 
-This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackStatusEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as a parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackStatusEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setStatusCallback](http://www.php.net/manual/en/gearmanclient.setstatuscallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -90,8 +100,10 @@ For more information about this GearmanEvent, read [GearmanClient::setStatusCall
 Warning Callback
 ~~~~~~~~~~~~~~~~
 
-This event receives as parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackWarningEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackWarningEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setWarningCallback](http://www.php.net/manual/en/gearmanclient.setwarningcallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 
@@ -104,8 +116,10 @@ For more information about this GearmanEvent, read [GearmanClient::setWarningCal
 Workload Callback
 ~~~~~~~~~~~~~~~~~
 
-This event receives as parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackWorkloadEvent` with one method `$event->getGearmanTask()`. This method returns an instance of `\GearmanTask`.
+This event receives as parameter an instance of `Mmoreram\GearmanBundle\Event\GearmanClientCallbackWorkloadEvent` with methods `$event->getGearmanTask()` and `&$event->getContext()`.
+First method returns an instance of `\GearmanTask`.
 For more information about this GearmanEvent, read [GearmanClient::setWorkloadCallback](http://www.php.net/manual/en/gearmanclient.setworkloadcallback.php) documentation.
+The second method will return `$context` that you could add in the `addTask()` method.
 
 .. code-block:: yml
 

--- a/Service/GearmanClient.php
+++ b/Service/GearmanClient.php
@@ -595,13 +595,13 @@ class GearmanClient extends AbstractGearmanService
      *
      * @return GearmanClient Return this object
      */
-    protected function enqueueTask($name, $params, $context, $unique, $method)
+    protected function enqueueTask($name, $params, &$context, $unique, $method)
     {
-
+        $contextReference = array('context' => &$context);
         $task = array(
             'name'    => $name,
             'params'  => $params,
-            'context' => $context,
+            'context' => $contextReference,
             'unique'  => $this->uniqueJobIdentifierGenerator->generateUniqueKey($name, $params, $unique, $method),
             'method'  => $method,
         );


### PR DESCRIPTION
Parameter `$context` is already passed by reference in methods `addTask*()` and `enqueueTask()` but it has no value at all because it can't be fetched and modified.

I added the `context` field to Event object so now everyone will have ability to get and modify it in the worker's callbacks.

Example of usage:

**Controller**:
```php
public function gearmanAction()
{
	$gearman = $this->get('gearman');
	
	$context = array();

	$gearman
		->addTask('workerName~job', 'param', $context)
		->runTasks();

	var_dump($context);

	return new Response();
}
```

**Worker**:
```php
public function onComplete($event)
{
	$context = &$event->getContext();
	$context[] = $event->getGearmanTask()->data();
	return true;
}
```