### PR TITLE
add GearmanWorker as optional argument

### DIFF
--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -357,15 +357,17 @@ class GearmanExecute extends AbstractGearmanService
      * Executes a worker given a workerName subscribing all his jobs inside and
      * given settings and annotations of worker and jobs
      *
-     * @param string $workerName Name of worker to be executed
+     * @param   string          $workerName     Name of worker to be executed
+     * @param   array           $options        Array of options passed to the callback
+     * @param   \GearmanWorker  $gearmanWorker
      */
-    public function executeWorker($workerName, array $options = array())
+    public function executeWorker($workerName, array $options = array(), \GearmanWorker $gearmanWorker = null)
     {
         $worker = $this->getWorker($workerName);
 
         if (false !== $worker) {
 
-            $this->callJob($worker, $options);
+            $this->callJob($worker, $options, $gearmanWorker);
         }
     }
 


### PR DESCRIPTION
add GearmanWorker as optional argument to keep track of return code (etc.) when executing (forking) multiple instances.