### PR TITLE
#169

### DIFF
--- a/Resources/config/commands.yml
+++ b/Resources/config/commands.yml
@@ -4,7 +4,7 @@ services:
     # Commands
     #
     gearman.command.cache_clear:
-        class: %gearman.command.cache_clear.class%
+        class: "%gearman.command.cache_clear.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanCacheWrapper", ["@gearman.cache.wrapper"]]
@@ -12,7 +12,7 @@ services:
             - { name: console.command }
 
     gearman.command.cache_warmup:
-        class: %gearman.command.cache_warmup.class%
+        class: "%gearman.command.cache_warmup.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanCacheWrapper", ["@gearman.cache.wrapper"]]
@@ -20,7 +20,7 @@ services:
             - { name: console.command }
 
     gearman.command.job_describe:
-        class: %gearman.command.job_describe.class%
+        class: "%gearman.command.job_describe.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanClient", ["@gearman"]]
@@ -29,7 +29,7 @@ services:
             - { name: console.command }
 
     gearman.command.job_execute:
-        class: %gearman.command.job_execute.class%
+        class: "%gearman.command.job_execute.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanClient", ["@gearman"]]
@@ -39,7 +39,7 @@ services:
             - { name: console.command }
 
     gearman.command.worker_describe:
-        class: %gearman.command.worker_describe.class%
+        class: "%gearman.command.worker_describe.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanClient", ["@gearman"]]
@@ -48,7 +48,7 @@ services:
             - { name: console.command }
 
     gearman.command.worker_execute:
-        class: %gearman.command.worker_execute.class%
+        class: "%gearman.command.worker_execute.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanClient", ["@gearman"]]
@@ -58,7 +58,7 @@ services:
             - { name: console.command }
 
     gearman.command.worker_list:
-        class: %gearman.command.worker_list.class%
+        class: "%gearman.command.worker_list.class%"
         calls:
             - ["setKernel", ["@kernel"]]
             - ["setGearmanClient", ["@gearman"]]

--- a/Resources/config/eventDispatchers.yml
+++ b/Resources/config/eventDispatchers.yml
@@ -10,4 +10,4 @@ services:
 
     gearman.dispatcher.callbacks:
         parent: gearman.dispatcher.abstract
-        class: %gearman.dispatcher.callbacks.class%
+        class: "%gearman.dispatcher.callbacks.class%"

--- a/Resources/config/externals.yml
+++ b/Resources/config/externals.yml
@@ -4,4 +4,4 @@ services:
     # Externals
     #
     gearman.external.symfony_finder:
-        class: %gearman.external.symfony_finder.class%
+        class: "%gearman.external.symfony_finder.class%"

--- a/Resources/config/generators.yml
+++ b/Resources/config/generators.yml
@@ -4,6 +4,6 @@ services:
     # Generators
     #
     gearman.unique_job_identifier:
-        class: %gearman.unique_job_identifier.class%
+        class: "%gearman.unique_job_identifier.class%"
         arguments:
-            generate_unique_key: %gearman.default.settings.generate_unique_key%
+            generate_unique_key: "%gearman.default.settings.generate_unique_key%"

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,29 +4,29 @@ services:
     # Services
     #
     gearman.parser:
-        class: %gearman.parser.class%
+        class: "%gearman.parser.class%"
         arguments:
             kernel: "@kernel"
             annotations_reader: "@annotation_reader"
             symfony_finder: "@gearman.external.symfony_finder"
-            gearman_bundles: %gearman.bundles%
-            gearman_servers: %gearman.servers%
-            gearman_default_settings: %gearman.default.settings%
+            gearman_bundles: "%gearman.bundles%"
+            gearman_servers: "%gearman.servers%"
+            gearman_default_settings: "%gearman.default.settings%"
 
     gearman.cache.wrapper:
-        class: %gearman.cache.wrapper.class%
+        class: "%gearman.cache.wrapper.class%"
         arguments:
             gearman_parser: "@gearman.parser"
             gearman_cache: "@doctrine_cache.providers.gearman_cache"
-            gearman_cache_id: %gearman.cache.id%
+            gearman_cache_id: "%gearman.cache.id%"
         calls:
-            - [load,  ["@doctrine_cache.providers.gearman_cache", %gearman.cache.id%]]
+            - [load,  ["@doctrine_cache.providers.gearman_cache", "%gearman.cache.id%"]]
         tags:
             - { name: kernel.cache_clearer }
             - { name: kernel.cache_warmer, priority: 0 }
 
     gearman.describer:
-        class: %gearman.describer.class%
+        class: "%gearman.describer.class%"
         arguments:
             kernel: "@kernel"
 
@@ -34,21 +34,21 @@ services:
         abstract:  true
         arguments:
             gearman_cache_wrapper: "@gearman.cache.wrapper"
-            default_settings: %gearman.default.settings%
+            default_settings: "%gearman.default.settings%"
 
     gearman.execute:
-        class: %gearman.execute.class%
+        class: "%gearman.execute.class%"
         parent: gearman.abstract.service
         calls:
             - [setContainer,  ["@service_container"]]
             - [setEventDispatcher, ["@event_dispatcher"]]
 
     gearman:
-        class: %gearman.client.class%
+        class: "%gearman.client.class%"
         parent: gearman.abstract.service
         calls:
             - [initTaskStructure, []]
-            - [setDefaultServers, [%gearman.servers%]]
+            - [setDefaultServers, ["%gearman.servers%"]]
             - [setGearmanCallbacksDispatcher, ["@gearman.dispatcher.callbacks"]]
             - [setUniqueJobIdentifierGenerator, ["@gearman.unique_job_identifier"]]
-            - [setDefaultSettings, [%gearman.default.settings%]]
+            - [setDefaultSettings, ["%gearman.default.settings%"]]

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -322,8 +322,7 @@ class GearmanExecute extends AbstractGearmanService
 
             $gearmanWorker->addFunction(
                 $job['realCallableName'],
-                array($this, 'handleJob'),
-                $this->workersBucket[$job['realCallableName']]
+                array($this, 'handleJob')
             );
         }
 
@@ -420,8 +419,15 @@ class GearmanExecute extends AbstractGearmanService
      *
      * @return mixed
      */
-    public function handleJob(\GearmanJob $job, $context)
+    public function handleJob(\GearmanJob $job)
     {
+
+        if(!isset($this->workersBucket[$job->functionName()])){
+            $context = false;
+        }else{
+            $context = $this->workersBucket[$job->functionName()];
+        }
+
         if (
             !is_array($context)
             || !array_key_exists('job_object_instance', $context)


### PR DESCRIPTION
See issue #169.

This commit fixes weird issue. To clarify what was wrong:
- `addFunction` needs `$context` param to be a _reference_, not value. Someone (I have not checked who) ignored docs and passed the second one,
- when I extracted array to a local variable, segfault also occurred - probably due to the incorrect garbage collection,
- configuration (and object with worker) left in `GearmanExecute::$workersBucket` survives GC and works ok.
