### PR TITLE
Add event listener on job complete that flushes the swiftmailer spool

### DIFF
--- a/EventListener/SwiftmailerEmailSenderListener.php
+++ b/EventListener/SwiftmailerEmailSenderListener.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * Gearman Bundle for Symfony2
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Dominic Luechinger <dol+symfony@cyon.ch>
+ */
+
+namespace Mmoreram\GearmanBundle\EventListener;
+
+use Mmoreram\GearmanBundle\GearmanEvents;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\EventDispatcher\EventSubscriberInterface;
+
+/**
+ * Sends emails for the memory spool.
+ *
+ * Emails are sent on the gearman.client.callback.complete event.
+ *
+ * @author Dominic Luechinger <dol+symfony@cyon.ch>
+ */
+class SwiftmailerEmailSenderListener implements EventSubscriberInterface
+{
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * Set container
+     *
+     * @param ContainerInterface $container Container
+     *
+     * @return GearmanExecute self Object
+     */
+    public function setContainer(ContainerInterface $container)
+    {
+        $this->container = $container;
+
+        return $this;
+    }
+
+    public function onComplete()
+    {
+        if (!$this->container->has('swiftmailer.email_sender.listener')) {
+            return;
+        }
+        $this->container->get('swiftmailer.email_sender.listener')->onTerminate();
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    public static function getSubscribedEvents()
+    {
+        return array(
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_COMPLETE => 'onComplete',
+        );
+    }
+}

--- a/Resources/config/classes.yml
+++ b/Resources/config/classes.yml
@@ -26,6 +26,11 @@ parameters:
     gearman.cache.wrapper.class: Mmoreram\GearmanBundle\Service\GearmanCacheWrapper
 
     #
+    # EventListeners
+    #
+    gearman.swiftmailer_email_sender.listener.class: Mmoreram\GearmanBundle\EventListener\SwiftmailerEmailSenderListener
+
+    #
     # Commands
     #
     gearman.command.cache_clear.class: Mmoreram\GearmanBundle\Command\GearmanCacheClearCommand

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -41,7 +41,13 @@ services:
         parent: gearman.abstract.service
         calls:
             - [setContainer,  ["@service_container"]]
-            - [setEventDispatcher, ["@event_dispatcher"]]
+
+    gearman.swiftmailer_email_sender.listener:
+        class: "%gearman.swiftmailer_email_sender.listener.class%"
+        calls:
+            - [setContainer,  ["@service_container"]]
+        tags:
+            - { name: kernel.event_subscriber }
 
     gearman:
         class: "%gearman.client.class%"


### PR DESCRIPTION
When starting with a default symfony project the swiftmailer is set-upped to use spool for sending out mails.
 https://github.com/symfony/symfony-standard/blob/7a885f1dcd2f5191f19470866aca9a472770ebcf/app/config/config.yml#L69

The spool is only flushed sent out on the [kernel terminate event](https://github.com/symfony/swiftmailer-bundle/blob/7cc472f19ad6259b3ffa09016d03b23d0037868d/EventListener/EmailSenderListener.php#L78). When using this bundle the kernel terminate event won't be triggered. This will block the emails in memory and they are never released. A Ctrl+C will interrupt the worker but not flushing the email either.

By adding a custom EventListener to the bundle this issue could be fixed.
An other approach would be creating a specialized SwiftMailerGearmanBundle that deals with GearmanBundle events and flushes the SwiftMailer spool. But this is kind of an overload.