### PR TITLE
(hotfix) - fixed deprecated message for symfony/options-resolver. 'Ca…

### DIFF
--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -89,12 +89,10 @@ class GearmanExecute extends AbstractGearmanService
                 'minimum_execution_time' => null,
                 'timeout'                => null,
             ))
-            ->setAllowedTypes(array(
-                'iterations'             => array('null', 'scalar'),
-                'minimum_execution_time' => array('null', 'scalar'),
-                'timeout'                => array('null', 'scalar'),
-            ))
-        ;
+	    ->setAllowedTypes('iterations', array('null', 'scalar'))
+            ->setAllowedTypes('minimum_execution_time', array('null', 'scalar'))
+            ->setAllowedTypes('timeout', array('null', 'scalar'));
+        
 
         $this->stopWorkSignalReceived = false;
 

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -89,12 +89,17 @@ class GearmanExecute extends AbstractGearmanService
                 'minimum_execution_time' => null,
                 'timeout'                => null,
             ))
-            ->setAllowedTypes(array(
-                'iterations'             => array('null', 'scalar'),
-                'minimum_execution_time' => array('null', 'scalar'),
-                'timeout'                => array('null', 'scalar'),
-            ))
         ;
+        foreach (
+            array(
+                'iterations' => array('null', 'scalar'),
+                'minimum_execution_time' => array('null', 'scalar'),
+                'timeout' => array('null', 'scalar')
+            ) as $option => $allowedTypes) {
+            $this->executeOptionsResolver->setAllowedTypes($option, $allowedTypes);
+        }
+
+
 
         $this->stopWorkSignalReceived = false;
 

--- a/Service/GearmanExecute.php
+++ b/Service/GearmanExecute.php
@@ -89,17 +89,12 @@ class GearmanExecute extends AbstractGearmanService
                 'minimum_execution_time' => null,
                 'timeout'                => null,
             ))
-        ;
-        foreach (
-            array(
-                'iterations' => array('null', 'scalar'),
+            ->setAllowedTypes(array(
+                'iterations'             => array('null', 'scalar'),
                 'minimum_execution_time' => array('null', 'scalar'),
-                'timeout' => array('null', 'scalar')
-            ) as $option => $allowedTypes) {
-            $this->executeOptionsResolver->setAllowedTypes($option, $allowedTypes);
-        }
-
-
+                'timeout'                => array('null', 'scalar'),
+            ))
+        ;
 
         $this->stopWorkSignalReceived = false;
 


### PR DESCRIPTION
…lling the Symfony\Component\OptionsResolver\OptionsResolver::setAllowedTypes method with an array of options is deprecated since version 2.6 and will be removed in 3.0. Use the new signature with a single option instead.'