### PR TITLE
configuration.rst: remove duplicate block about dev caching

### DIFF
--- a/Resources/docs/configuration.rst
+++ b/Resources/docs/configuration.rst
@@ -98,25 +98,13 @@ config gearman cache, using doctrine cache.
              port: 4730
 
 In development mode you do not want to cache things over more than one
-request. An easy solution for this is to use the array provider in the dev
-environment ( Extracted from `DoctrineCacheBundle`_ documentation )
-
-.. code-block:: yml
-
-    #config.yml
-    doctrine_cache:
-        providers:
-            gearman_cache:
-                type: file_system
-                namespace: doctrine_cache.ns.gearman
-
-In development mode you do not want to cache things over more than one
 request. An easy solution for this is to use the array cache in the dev
 environment ( Extracted from `DoctrineCacheBundle`_ documentation )
 
 .. code-block:: yml
 
     #config_dev.yml
+    
     doctrine_cache:
         providers:
             gearman_cache:


### PR DESCRIPTION
[configuration.rst](https://gearmanbundle.readthedocs.io/en/latest/configuration.html) contains a duplicate documentation block about disable caching in dev. This is quite misleading - plus, the right one (mentioning config_dev.yml) is the second one