### PR TITLE
Updated GearmanDescriber to detect proper path for console script

### DIFF
--- a/Service/GearmanDescriber.php
+++ b/Service/GearmanDescriber.php
@@ -30,12 +30,6 @@ class GearmanDescriber
      */
     private $kernel;
 
-    /**
-     * Root kernel directory
-     *
-     * @var string
-     */
-    private $rootDir;
 
     /**
      * Construct method
@@ -45,14 +39,6 @@ class GearmanDescriber
     public function __construct(KernelInterface $kernel)
     {
         $this->kernel = $kernel;
-
-        // Symfony 3.3+ compatibility, get kernel root dir
-        if(method_exists($this->kernel, 'getProjectDir')){
-            $r = new \ReflectionObject($this->kernel);
-            $this->rootDir = \dirname($r->getFileName());
-        } else {
-            $this->rootDir = $this->kernel->getRootDir();
-        }
     }
 
     /**
@@ -68,7 +54,7 @@ class GearmanDescriber
         /**
          * Commandline
          */
-        $script = $this->rootDir . '/console gearman:job:execute';
+        $script = $this->getConsolePath() . 'gearman:job:execute';
 
         /**
          * A job descriptions contains its worker description
@@ -124,7 +110,7 @@ class GearmanDescriber
         /**
          * Commandline
          */
-        $script = $this->rootDir . '/console gearman:worker:execute';
+        $script = $this->getConsolePath() . ' gearman:worker:execute';
 
         $output->writeln('');
         $output->writeln('<info>@Worker\className : ' . $worker['className'] . '</info>');
@@ -181,5 +167,22 @@ class GearmanDescriber
         $output->writeln('');
         $output->writeln('<comment>    ' . $worker['description'] . '</comment>');
         $output->writeln('');
+    }
+
+    private function getConsolePath()
+    {
+        // Symfony 3.3+ compatibility, get kernel root dir
+        if(method_exists($this->kernel, 'getProjectDir') && false){
+            $projectDir = $this->kernel->getProjectDir();
+        } else {
+            $projectDir = $this->kernel->getRootDir().'/..';
+        }
+
+        if(true === file_exists($projectDir.'/bin/console')){
+            return realpath($projectDir. '/bin/console');
+        } else {
+            return realpath($projectDir. '/app/console');
+        }
+
     }
 }


### PR DESCRIPTION
Fixes #194 .  Currently the GearmanDescriber outputs the wrong console path for Symfony4+ as it is based on the "Kernel" directory.  This update will try to see if bin/console from the project root exists first if it does it will return that.  Otherwise it will fallback to the app/console version.