### PR TITLE
Update GearmanDescriber.php

### DIFF
--- a/Service/GearmanDescriber.php
+++ b/Service/GearmanDescriber.php
@@ -172,7 +172,7 @@ class GearmanDescriber
     private function getConsolePath()
     {
         // Symfony 3.3+ compatibility, get kernel root dir
-        if(method_exists($this->kernel, 'getProjectDir') && false){
+        if(method_exists($this->kernel, 'getProjectDir')){
             $projectDir = $this->kernel->getProjectDir();
         } else {
             $projectDir = $this->kernel->getRootDir().'/..';


### PR DESCRIPTION
We still see `The "Symfony\Component\HttpKernel\Kernel::getRootDir()" method is deprecated since Symfony 4.2, use getProjectDir() instead.`, coming from `GearmanDescriber.php:178`

I think the current state is a debug leftover from #196, or im missing it :)

```
dd(
    method_exists($this->kernel, 'getProjectDir') && false,
    method_exists($this->kernel, 'getProjectDir')
);

^ false
^ true
```