### PR TITLE
BC layer symfony/event-dispatcher

### DIFF
--- a/Dispatcher/GearmanCallbacksDispatcher.php
+++ b/Dispatcher/GearmanCallbacksDispatcher.php
@@ -25,6 +25,7 @@ use Mmoreram\GearmanBundle\Event\GearmanClientCallbackStatusEvent;
 use Mmoreram\GearmanBundle\Event\GearmanClientCallbackWarningEvent;
 use Mmoreram\GearmanBundle\Event\GearmanClientCallbackWorkloadEvent;
 use Mmoreram\GearmanBundle\GearmanEvents;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 /**
  * Gearman callbacks
@@ -96,9 +97,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
         if (!is_null($contextReference)) {
             $event->setContext($contextReference);
         }
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_COMPLETE,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_COMPLETE
         );
     }
 
@@ -112,9 +113,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignFailCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackFailEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_FAIL,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_FAIL
         );
     }
 
@@ -128,9 +129,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignDataCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackDataEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_DATA,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_DATA
         );
     }
 
@@ -144,9 +145,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignCreatedCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackCreatedEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_CREATED,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_CREATED
         );
     }
 
@@ -158,9 +159,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignExceptionCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackExceptionEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_EXCEPTION,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_EXCEPTION
         );
     }
 
@@ -174,9 +175,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignStatusCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackStatusEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_STATUS,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_STATUS
         );
     }
 
@@ -190,9 +191,9 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignWarningCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackWarningEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_WARNING,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_WARNING
         );
     }
 
@@ -206,9 +207,21 @@ class GearmanCallbacksDispatcher extends AbstractGearmanDispatcher
     public function assignWorkloadCallback(GearmanTask $gearmanTask)
     {
         $event = new GearmanClientCallbackWorkloadEvent($gearmanTask);
-        $this->eventDispatcher->dispatch(
-            GearmanEvents::GEARMAN_CLIENT_CALLBACK_WORKLOAD,
-            $event
+        $this->dispatch(
+            $event,
+            GearmanEvents::GEARMAN_CLIENT_CALLBACK_WORKLOAD
         );
+    }
+
+    private function dispatch($event, $eventName)
+    {
+        // LegacyEventDispatcherProxy exists in Symfony >= 4.3
+        if (class_exists(LegacyEventDispatcherProxy::class)) {
+            // New Symfony 4.3 EventDispatcher signature
+            $this->eventDispatcher->dispatch($event, $eventName);
+        } else {
+            // Old EventDispatcher signature
+            $this->eventDispatcher->dispatch($eventName, $event);
+        }
     }
 }

--- a/Event/Abstracts/AbstractGearmanClientTaskEvent.php
+++ b/Event/Abstracts/AbstractGearmanClientTaskEvent.php
@@ -14,7 +14,6 @@
 namespace Mmoreram\GearmanBundle\Event\Abstracts;
 
 use GearmanTask;
-use Symfony\Component\EventDispatcher\Event;
 
 /**
  * AbstractGearmanClientTaskEvent

--- a/Event/Abstracts/Event.php
+++ b/Event/Abstracts/Event.php
@@ -1,0 +1,34 @@
+<?php
+
+/**
+ * Gearman Bundle for Symfony2
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ *
+ * Feel free to edit as you please, and have fun.
+ *
+ * @author Marc Morera <yuhu@mmoreram.com>
+ */
+
+namespace Mmoreram\GearmanBundle\Event\Abstracts;
+
+use Symfony\Component\EventDispatcher\Event as BaseEventDeprecated;
+use Symfony\Contracts\EventDispatcher\Event as BaseEvent;
+
+// Symfony 4.3 BC layer
+if (class_exists(BaseEvent::class)) {
+    /**
+     * @internal
+     */
+    abstract class Event extends BaseEvent
+    {
+    }
+} else {
+    /**
+     * @internal
+     */
+    abstract class Event extends BaseEventDeprecated
+    {
+    }
+}

--- a/Event/GearmanWorkExecutedEvent.php
+++ b/Event/GearmanWorkExecutedEvent.php
@@ -13,8 +13,7 @@
 
 namespace Mmoreram\GearmanBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
-use Symfony\Component\EventDispatcher\Event;
+use Mmoreram\GearmanBundle\Event\Abstracts\Event;
 
 /**
  * GearmanWorkExecutedEvent

--- a/Event/GearmanWorkExecutedEvent.php
+++ b/Event/GearmanWorkExecutedEvent.php
@@ -14,6 +14,7 @@
 namespace Mmoreram\GearmanBundle\Event;
 
 use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\EventDispatcher\Event;
 
 /**
  * GearmanWorkExecutedEvent

--- a/Event/GearmanWorkStartingEvent.php
+++ b/Event/GearmanWorkStartingEvent.php
@@ -13,7 +13,7 @@
 
 namespace Mmoreram\GearmanBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Mmoreram\GearmanBundle\Event\Abstracts\Event;
 
 /**
  * GearmanWorkStartingEvent


### PR DESCRIPTION
this could  generally work as a patch-release IMHO.

A potential BC break can occur if someone relies on type checking the deprecated event class, whereas the new release will extend the contract-event class ...

Any next-version works for us :+1: 